### PR TITLE
Production-readiness: health endpoint, graceful shutdown, pool tuning, resource limits, backup

### DIFF
--- a/apps/web/src/routes/api/health/+server.js
+++ b/apps/web/src/routes/api/health/+server.js
@@ -1,0 +1,44 @@
+import { json } from "@sveltejs/kit";
+import { pool } from "@meshhook/shared/lib/db.js";
+
+const startTime = Date.now();
+
+export async function GET() {
+  let dbOk = false;
+  let poolInfo = { totalCount: 0, idleCount: 0, waitingCount: 0 };
+  let dbError = null;
+
+  try {
+    const client = await pool.connect();
+    try {
+      await client.query("SELECT 1");
+      dbOk = true;
+    } finally {
+      client.release();
+    }
+    poolInfo = {
+      totalCount: pool.totalCount,
+      idleCount: pool.idleCount,
+      waitingCount: pool.waitingCount,
+    };
+  } catch (err) {
+    dbError = err.message;
+  }
+
+  const status = dbOk ? 200 : 503;
+
+  return json(
+    {
+      status: dbOk ? "healthy" : "degraded",
+      uptime: Math.round((Date.now() - startTime) / 1000),
+      database: {
+        ok: dbOk,
+        pool: poolInfo,
+        error: dbError,
+      },
+      memory: process.memoryUsage(),
+      pid: process.pid,
+    },
+    { status }
+  );
+}

--- a/packages/shared/lib/db.js
+++ b/packages/shared/lib/db.js
@@ -3,43 +3,61 @@ import { config } from "dotenv";
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
 
-// Load environment variables
-// In production, .env is used (not committed)
-// In development, .env.local is used (committed for easy setup)
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const rootDir = join(__dirname, "../..");
 
-// Try to load .env first (production), then fall back to .env.local (development)
 config({ path: join(rootDir, ".env") });
 config({ path: join(rootDir, ".env.local") });
 
-// Validate DATABASE_URL is set
 if (!process.env.DATABASE_URL) {
-  throw new Error(
-    "DATABASE_URL is not set. Please check your .env or .env.local file."
-  );
+  throw new Error("DATABASE_URL is not set. Check .env or .env.local.");
 }
 
-const pool = new pg.Pool({ connectionString: process.env.DATABASE_URL });
+const pool = new pg.Pool({
+  connectionString: process.env.DATABASE_URL,
+  max: parseInt(process.env.DB_POOL_MAX || "20", 10),
+  idleTimeoutMillis: parseInt(process.env.DB_POOL_IDLE_TIMEOUT || "30000", 10),
+  connectionTimeoutMillis: parseInt(process.env.DB_POOL_CONNECTION_TIMEOUT || "5000", 10),
+});
+
+pool.on("error", (err) => {
+  console.error("db pool error:", err.message);
+});
+
+export async function healthCheck() {
+  const client = await pool.connect();
+  try {
+    await client.query("SELECT 1");
+    return { ok: true, poolSize: pool.totalCount, idleCount: pool.idleCount };
+  } finally {
+    client.release();
+  }
+}
+
 export const db = {
-  one: async (q, p=[]) => (await pool.query(q, p)).rows[0],
-  oneOrNone: async (q, p=[]) => (await pool.query(q, p)).rows[0] ?? null,
-  manyOrNone: async (q, p=[]) => (await pool.query(q, p)).rows,
-  none: async (q, p=[]) => { await pool.query(q, p); },
+  one: async (q, p = []) => (await pool.query(q, p)).rows[0],
+  oneOrNone: async (q, p = []) => (await pool.query(q, p)).rows[0] ?? null,
+  manyOrNone: async (q, p = []) => (await pool.query(q, p)).rows,
+  none: async (q, p = []) => { await pool.query(q, p); },
   tx: async (fn) => {
     const client = await pool.connect();
     try {
       await client.query("begin");
       const tdb = {
-        one: (q,p=[]) => client.query(q,p).then(r=>r.rows[0]),
-        none: (q,p=[]) => client.query(q,p).then(()=>{}),
+        one: (q, p = []) => client.query(q, p).then((r) => r.rows[0]),
+        none: (q, p = []) => client.query(q, p).then(() => {}),
       };
       const res = await fn(tdb);
       await client.query("commit");
       return res;
     } catch (e) {
-      await client.query("rollback"); throw e;
-    } finally { client.release(); }
-  }
+      await client.query("rollback");
+      throw e;
+    } finally {
+      client.release();
+    }
+  },
 };
+
+export { pool };

--- a/scripts/backup.js
+++ b/scripts/backup.js
@@ -1,0 +1,39 @@
+import { execSync } from "child_process";
+import { mkdirSync, readdirSync, statSync, unlinkSync } from "fs";
+import { join } from "path";
+
+const DB_URL = process.env.DATABASE_URL;
+const BACKUP_DIR = process.env.BACKUP_DIR || join(process.cwd(), "backups");
+const RETENTION_DAYS = parseInt(process.env.BACKUP_RETENTION_DAYS || "7", 10);
+
+if (!DB_URL) {
+  console.error("DATABASE_URL required");
+  process.exit(1);
+}
+
+mkdirSync(BACKUP_DIR, { recursive: true });
+
+const ts = new Date().toISOString().replace(/[:.]/g, "-");
+const path = join(BACKUP_DIR, `meshhook-${ts}.sql`);
+
+try {
+  execSync(`pg_dump "${DB_URL}" --no-owner --no-acl -f "${path}"`, {
+    stdio: "pipe",
+    timeout: 120_000,
+  });
+} catch (err) {
+  console.error("backup failed:", err.stderr?.toString() || err.message);
+  process.exit(1);
+}
+
+console.log(`backup written: ${path} (${statSync(path).size} bytes)`);
+
+const cutoff = Date.now() - RETENTION_DAYS * 86400_000;
+for (const f of readdirSync(BACKUP_DIR)) {
+  const fp = join(BACKUP_DIR, f);
+  const st = statSync(fp);
+  if (st.isFile() && st.mtimeMs < cutoff) {
+    unlinkSync(fp);
+    console.log(`removed old backup: ${f}`);
+  }
+}

--- a/workers/http-exec.mjs
+++ b/workers/http-exec.mjs
@@ -1,7 +1,9 @@
 import { setTimeout as delay } from "node:timers/promises";
-import { db } from "./lib/db.js";
+import { db, pool } from "./lib/db.js";
 import { queue } from "./lib/queue.js";
 import { request as undiciRequest } from "undici";
+import { createShutdown } from "./lib/graceful-shutdown.js";
+import { startMemoryWatcher, stopMemoryWatcher } from "./lib/resource-limits.js";
 
 async function execHttp(runId, node) {
   const req = {
@@ -67,7 +69,12 @@ async function handleStep(job) {
 
 export async function startHttpExec() {
   await queue.process("step:execute", handleStep);
-  console.log("🔧 MeshHook HTTP Executor running");
+  startMemoryWatcher();
+
+  const shutdown = createShutdown({ pool, label: "http-exec", preStop: stopMemoryWatcher });
+  shutdown.register();
+
+  console.log("MeshHook HTTP Executor running");
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) startHttpExec();

--- a/workers/lib/__tests__/resource-limits.test.js
+++ b/workers/lib/__tests__/resource-limits.test.js
@@ -1,0 +1,30 @@
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { startMemoryWatcher, stopMemoryWatcher, getResourceConfig } from "../resource-limits.js";
+
+describe("resource-limits", () => {
+  afterEach(() => {
+    stopMemoryWatcher();
+  });
+
+  it("should provide default config", () => {
+    const cfg = getResourceConfig();
+    assert.equal(cfg.maxMemMb, 512);
+    assert.equal(cfg.maxMemBytes, 512 * 1024 * 1024);
+    assert.equal(typeof cfg.cpuLimit, "number");
+    assert.ok(cfg.cpuLimit > 0);
+  });
+
+  it("should start and stop memory watcher without error", () => {
+    startMemoryWatcher(60_000);
+    stopMemoryWatcher();
+    assert.ok(true);
+  });
+
+  it("should be idempotent when started twice", () => {
+    startMemoryWatcher(60_000);
+    startMemoryWatcher(60_000);
+    stopMemoryWatcher();
+    assert.ok(true);
+  });
+});

--- a/workers/lib/db.js
+++ b/workers/lib/db.js
@@ -3,43 +3,61 @@ import { config } from "dotenv";
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
 
-// Load environment variables
-// In production, .env is used (not committed)
-// In development, .env.local is used (committed for easy setup)
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const rootDir = join(__dirname, "../..");
 
-// Try to load .env first (production), then fall back to .env.local (development)
 config({ path: join(rootDir, ".env") });
 config({ path: join(rootDir, ".env.local") });
 
-// Validate DATABASE_URL is set
 if (!process.env.DATABASE_URL) {
-  throw new Error(
-    "DATABASE_URL is not set. Please check your .env or .env.local file."
-  );
+  throw new Error("DATABASE_URL is not set. Check .env or .env.local.");
 }
 
-const pool = new pg.Pool({ connectionString: process.env.DATABASE_URL });
+const pool = new pg.Pool({
+  connectionString: process.env.DATABASE_URL,
+  max: parseInt(process.env.DB_POOL_MAX || "20", 10),
+  idleTimeoutMillis: parseInt(process.env.DB_POOL_IDLE_TIMEOUT || "30000", 10),
+  connectionTimeoutMillis: parseInt(process.env.DB_POOL_CONNECTION_TIMEOUT || "5000", 10),
+});
+
+pool.on("error", (err) => {
+  console.error("db pool error:", err.message);
+});
+
+export async function healthCheck() {
+  const client = await pool.connect();
+  try {
+    await client.query("SELECT 1");
+    return { ok: true, poolSize: pool.totalCount, idleCount: pool.idleCount };
+  } finally {
+    client.release();
+  }
+}
+
 export const db = {
-  one: async (q, p=[]) => (await pool.query(q, p)).rows[0],
-  oneOrNone: async (q, p=[]) => (await pool.query(q, p)).rows[0] ?? null,
-  manyOrNone: async (q, p=[]) => (await pool.query(q, p)).rows,
-  none: async (q, p=[]) => { await pool.query(q, p); },
+  one: async (q, p = []) => (await pool.query(q, p)).rows[0],
+  oneOrNone: async (q, p = []) => (await pool.query(q, p)).rows[0] ?? null,
+  manyOrNone: async (q, p = []) => (await pool.query(q, p)).rows,
+  none: async (q, p = []) => { await pool.query(q, p); },
   tx: async (fn) => {
     const client = await pool.connect();
     try {
       await client.query("begin");
       const tdb = {
-        one: (q,p=[]) => client.query(q,p).then(r=>r.rows[0]),
-        none: (q,p=[]) => client.query(q,p).then(()=>{}),
+        one: (q, p = []) => client.query(q, p).then((r) => r.rows[0]),
+        none: (q, p = []) => client.query(q, p).then(() => {}),
       };
       const res = await fn(tdb);
       await client.query("commit");
       return res;
     } catch (e) {
-      await client.query("rollback"); throw e;
-    } finally { client.release(); }
-  }
+      await client.query("rollback");
+      throw e;
+    } finally {
+      client.release();
+    }
+  },
 };
+
+export { pool };

--- a/workers/lib/graceful-shutdown.js
+++ b/workers/lib/graceful-shutdown.js
@@ -1,0 +1,30 @@
+export function createShutdown({ pool, label = "worker", preStop, onShutdown } = {}) {
+  let shuttingDown = false;
+
+  async function shutdown(signal) {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    console.log(`${label}: received ${signal}, draining...`);
+
+    try {
+      if (preStop) await preStop();
+
+      if (pool) {
+        await pool.end();
+        console.log(`${label}: pool closed`);
+      }
+    } catch (err) {
+      console.error(`${label}: shutdown error:`, err);
+    }
+
+    if (onShutdown) await onShutdown();
+    process.exit(0);
+  }
+
+  function register() {
+    process.on("SIGTERM", () => shutdown("SIGTERM"));
+    process.on("SIGINT", () => shutdown("SIGINT"));
+  }
+
+  return { register, shutdown };
+}

--- a/workers/lib/resource-limits.js
+++ b/workers/lib/resource-limits.js
@@ -1,0 +1,60 @@
+import { availableParallelism } from "os";
+
+const MB = 1024 * 1024;
+
+function loadConfig() {
+  const maxMemMb = parseInt(process.env.MAX_MEMORY_MB || "512", 10);
+  const heapDump = process.env.HEAP_DUMP_ON_OOM === "true";
+  const cpuLimit = parseFloat(process.env.CPU_LIMIT || availableParallelism().toString());
+
+  return {
+    maxMemBytes: maxMemMb * MB,
+    maxMemMb,
+    heapDump,
+    cpuLimit,
+    warnThreshold: parseFloat(process.env.MEMORY_WARN_THRESHOLD || "0.85"),
+  };
+}
+
+const state = { config: loadConfig(), timer: null };
+
+async function checkMemory() {
+  const { heapUsed, rss } = process.memoryUsage();
+
+  if (rss > state.config.maxMemBytes) {
+    console.error(
+      `resource-limits: RSS ${Math.round(rss / MB)}MB exceeds limit ${state.config.maxMemMb}MB`
+    );
+    if (state.config.heapDump) {
+      try {
+        const { writeHeapSnapshot } = await import("v8");
+        writeHeapSnapshot();
+      } catch { /* not available */ }
+    }
+    throw new Error("RESOURCE_EXCEEDED");
+  }
+
+  if (heapUsed > state.config.maxMemBytes * state.config.warnThreshold) {
+    console.warn(
+      `resource-limits: heap ${Math.round(heapUsed / MB)}MB approaching limit ${state.config.maxMemMb}MB`
+    );
+  }
+}
+
+export function startMemoryWatcher(intervalMs = 30_000) {
+  if (state.timer) return;
+  setImmediate(() => checkMemory().catch(() => {}));
+  state.timer = setInterval(() => checkMemory().catch(() => {}), intervalMs);
+  state.timer.unref();
+}
+
+export function stopMemoryWatcher() {
+  if (state.timer) {
+    clearInterval(state.timer);
+    state.timer = null;
+  }
+}
+
+export function getResourceConfig() {
+  return { ...state.config };
+}

--- a/workers/orchestrator.mjs
+++ b/workers/orchestrator.mjs
@@ -1,5 +1,7 @@
-import { db } from "./lib/db.js";
+import { db, pool } from "./lib/db.js";
 import { queue, enqueueStep } from "./lib/queue.js";
+import { createShutdown } from "./lib/graceful-shutdown.js";
+import { startMemoryWatcher, stopMemoryWatcher } from "./lib/resource-limits.js";
 
 async function replay(runId) {
   const events = await db.manyOrNone(
@@ -45,7 +47,12 @@ async function handleRun(job) {
 
 export async function startOrchestrator() {
   await queue.process("run:orchestrate", handleRun);
-  console.log("🧠 MeshHook Orchestrator running");
+  startMemoryWatcher();
+
+  const shutdown = createShutdown({ pool, label: "orchestrator", preStop: stopMemoryWatcher });
+  shutdown.register();
+
+  console.log("MeshHook Orchestrator running");
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) startOrchestrator();


### PR DESCRIPTION
## Summary
Adds core production-readiness infrastructure to MeshHook workers and web app:

- **Health endpoint** (`GET /api/health`): reports DB pool status, uptime, memory, PID. Returns 503 when DB is unreachable.
- **Graceful shutdown**: workers (orchestrator, http-exec) now drain the pg pool on `SIGTERM`/`SIGINT` via a reusable `createShutdown` helper.
- **Connection pool tuning**: `packages/shared/lib/db.js` and `workers/lib/db.js` accept `DB_POOL_MAX` / `DB_POOL_IDLE_TIMEOUT` / `DB_POOL_CONNECTION_TIMEOUT` env vars (sensible defaults), plus a `healthCheck()` export.
- **Resource limits**: `workers/lib/resource-limits.js` — periodic RSS watcher with configurable `MAX_MEMORY_MB`, optional `HEAP_DUMP_ON_OOM`, warn threshold.
- **Backup**: `scripts/backup.js` — `pg_dump` snapshot with retention cleanup.
- Unit test for the memory watcher.

## Test plan
- `node --test workers/lib/__tests__/resource-limits.test.js` → 3/3 pass
- Manual: start worker, send `SIGTERM`, observe clean pool drain + exit 0

Closes #196, #197, #198, #199, #200