### PR TITLE
Make the orchestrator a real worker so it stops exiting on boot

### DIFF
--- a/migrations/0005_step_queue.sql
+++ b/migrations/0005_step_queue.sql
@@ -1,0 +1,15 @@
+-- Step queue configuration.
+--
+-- Node execution used to be dispatched over an in-process EventEmitter, which
+-- neither crossed a process boundary nor survived a restart. Steps are now
+-- durable queue rows like runs, so they need their own config entry.
+--
+-- The visibility timeout is longer than the run queue's: a step performs an
+-- outbound HTTP call with its own retries, so a 30s lease could lapse while the
+-- work is legitimately still in flight and cause a duplicate execution.
+
+insert into queue_config (
+  queue_name, visibility_timeout_seconds, max_retry_attempts,
+  retry_backoff_base_ms, retry_backoff_max_ms, dlq_enabled
+) values ('workflow_steps', 120, 5, 1000, 300000, 1)
+on conflict (queue_name) do nothing;

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -9,7 +9,12 @@ export default defineConfig({
     // Only the suites that are actually written for vitest. src/nodes,
     // src/workers and src/utils use the node:test runner instead and are run by
     // `pnpm run test:node`; collecting them here just reports "no test suite".
-    include: ["src/queue/**/*.test.js", "packages/**/*.test.js", "scripts/**/*.test.js"],
+    include: [
+      "src/queue/**/*.test.js",
+      "packages/**/*.test.js",
+      "scripts/**/*.test.js",
+      "workers/**/*.test.js",
+    ],
     exclude: ["**/node_modules/**", "apps/**"],
     // Queue tests exercise visibility timeouts and a polling worker.
     testTimeout: 15000,

--- a/workers/http-exec.mjs
+++ b/workers/http-exec.mjs
@@ -1,6 +1,5 @@
 import { setTimeout as delay } from "node:timers/promises";
 import { db } from "./lib/db.js";
-import { queue } from "./lib/queue.js";
 import { request as undiciRequest } from "undici";
 
 async function execHttp(runId, node) {
@@ -47,27 +46,41 @@ async function execHttp(runId, node) {
   }
 }
 
-async function handleStep(job) {
-  const { run_id: runId, node } = job.data;
+/**
+ * Execute one workflow node.
+ *
+ * This used to subscribe to an in-process EventEmitter. The orchestrator now
+ * owns the polling loop and calls this directly, so execution is driven by the
+ * durable workflow_steps queue instead — a step survives a restart, and a
+ * failure propagates to the worker, which retries or dead-letters it rather
+ * than logging into the void.
+ *
+ * @param {string} runId
+ * @param {{id: string, type: string}} node
+ */
+export async function executeStep(runId, node) {
   if (node.type === "http_call") {
     await execHttp(runId, node);
-  } else if (node.type === "transform") {
+    return;
+  }
+
+  if (node.type === "transform") {
     await db.none(
-      "insert into workflow_events (run_id, type, payload) values ($1,'step_succeeded',$2)",
+      "insert into workflow_events (run_id, type, payload) values (?, 'step_succeeded', ?)",
       [runId, JSON.stringify({ node, next: "createContact", output: { ok: true } })]
     );
-  } else if (node.type === "terminate") {
-    await db.none(
-      "insert into workflow_events (run_id, type, payload) values ($1,'run_completed',$2)",
-      [runId, JSON.stringify({ reason: "terminated" })]
-    );
-    await db.none("update workflow_runs set status='succeeded', finished_at=strftime('%Y-%m-%dT%H:%M:%fZ','now'), updated_at=strftime('%Y-%m-%dT%H:%M:%fZ','now') where id=$1", [runId]);
+    return;
   }
-}
 
-export async function startHttpExec() {
-  await queue.process("step:execute", handleStep);
-  console.log("🔧 MeshHook HTTP Executor running");
-}
+  if (node.type === "terminate") {
+    await db.none(
+      "insert into workflow_events (run_id, type, payload) values (?, 'step_succeeded', ?)",
+      [runId, JSON.stringify({ node, next: null, reason: "terminated" })]
+    );
+    return;
+  }
 
-if (import.meta.url === `file://${process.argv[1]}`) startHttpExec();
+  // An unknown node type must not look like success: leaving the run to be
+  // marked completed would hide a definition the engine cannot execute.
+  throw new Error(`Unknown node type "${node.type}" for node ${node.id}`);
+}

--- a/workers/lib/queue.js
+++ b/workers/lib/queue.js
@@ -1,17 +1,37 @@
-import { EventEmitter } from "node:events";
-const bus = new EventEmitter();
+/**
+ * Worker queue bindings.
+ *
+ * This was an in-process EventEmitter. Two things were wrong with that once the
+ * app moved off Supabase:
+ *
+ *  - Nothing crossed a process boundary. The web app enqueues a run when a
+ *    webhook arrives, but a separately deployed orchestrator listens on its own
+ *    EventEmitter and never hears it, so runs were silently dropped.
+ *  - `bus.on(...)` does not hold the event loop open. `node orchestrator.mjs`
+ *    registered a listener, printed its banner and exited immediately — which
+ *    is why the Railway container kept reporting EXITED.
+ *
+ * Both queues are now durable rows in the database, so work survives a restart
+ * and any number of worker processes can share it.
+ */
 
-export const queue = {
-  async process(topic, handler) {
-    bus.on(topic, async (data) => {
-      try { await handler({ data }); } catch (e) { console.error(e); }
-    });
-  }
-};
+import { Queue } from "@meshhook/shared/lib/queue.js";
 
-export async function enqueueRun(runId) {
-  bus.emit("run:orchestrate", { run_id: runId });
+/** Runs waiting for the orchestrator to decide their next step. */
+export const RUN_QUEUE = "workflow_jobs";
+
+/** Individual nodes waiting to be executed. */
+export const STEP_QUEUE = "workflow_steps";
+
+export const runQueue = new Queue({ name: RUN_QUEUE });
+export const stepQueue = new Queue({ name: STEP_QUEUE });
+
+/** Ask the orchestrator to advance a run. */
+export async function enqueueRun(runId, delaySeconds = 0) {
+  return runQueue.send({ run_id: runId }, delaySeconds);
 }
-export async function enqueueStep(runId, node) {
-  bus.emit("step:execute", { run_id: runId, node });
+
+/** Ask an executor to run a single node. */
+export async function enqueueStep(runId, node, delaySeconds = 0) {
+  return stepQueue.send({ run_id: runId, node }, delaySeconds);
 }

--- a/workers/orchestrator.mjs
+++ b/workers/orchestrator.mjs
@@ -1,52 +1,219 @@
-import { db, json } from "./lib/db.js";
-import { queue, enqueueStep } from "./lib/queue.js";
+/**
+ * MeshHook orchestrator.
+ *
+ * Long-running process that drains two durable queues:
+ *
+ *   workflow_jobs   a run needs its next step decided
+ *   workflow_steps  a node needs executing
+ *
+ * It previously registered two EventEmitter listeners and returned. That did
+ * not keep the event loop alive, so the process printed its banner and exited —
+ * Railway reported the container as EXITED on every deploy. It also meant runs
+ * enqueued by the web app (a different process) were never seen at all.
+ *
+ * Both worker loops poll the database, which holds the process open for as long
+ * as it is running and lets several instances share the work safely.
+ */
 
+import { db, json } from "./lib/db.js";
+import { RUN_QUEUE, STEP_QUEUE, enqueueRun, enqueueStep } from "./lib/queue.js";
+import { Worker } from "../src/queue/index.js";
+import { executeStep } from "./http-exec.mjs";
+
+/**
+ * Rebuild a run's position from its event log.
+ *
+ * The engine is event-sourced: the events are the source of truth, so a
+ * redelivered job recomputes the same answer rather than relying on any state
+ * held in the worker.
+ */
 async function replay(runId) {
   const events = await db.manyOrNone(
-    "select type, payload from workflow_events where run_id=$1 order by ts asc",
-    [runId]
+    "select type, payload from workflow_events where run_id = ? order by id asc",
+    [runId],
   );
-  let ctx = { current: null };
+
+  let current = null;
+  let started = false;
+  let terminated = false;
+
   for (const ev of events) {
     // payload is TEXT under SQLite, not a decoded jsonb value.
-    if (ev.type === "step_succeeded") ctx.current = json(ev.payload, {}).next ?? null;
+    const payload = json(ev.payload, {});
+
+    if (ev.type === "step_succeeded") {
+      started = true;
+      current = payload.next ?? null;
+      // A terminate node reports next: null, which is indistinguishable from
+      // "not started yet" on its own — track it separately or the run restarts
+      // from the first node forever.
+      if (payload.node?.type === "terminate") terminated = true;
+    }
+
+    if (ev.type === "run_completed") terminated = true;
   }
-  return ctx;
+
+  return { current, started, terminated };
 }
 
-async function nextNodesFor(runId) {
-  const ctx = await replay(runId);
-  if (!ctx.current) return [{ id: "mapLead", type: "transform" }];
-  if (ctx.current === "mapLead") return [{ id: "createContact", type: "http_call" }];
-  if (ctx.current === "createContact") return [{ id: "terminate", type: "terminate" }];
+/** The demo pipeline. Replaced by the workflow definition in issue #103. */
+export async function nextNodesFor(runId) {
+  const { current, started, terminated } = await replay(runId);
+
+  if (terminated) return [];
+  if (!started) return [{ id: "mapLead", type: "transform" }];
+  if (current === "mapLead") return [{ id: "createContact", type: "http_call" }];
+  if (current === "createContact") return [{ id: "terminate", type: "terminate" }];
   return [];
 }
 
-async function handleRun(job) {
-  const { run_id: runId } = job.data;
-  const nodes = await nextNodesFor(runId);
-  if (nodes.length === 0) {
-    await db.tx(async t => {
-      await t.none(
-        "insert into workflow_events (run_id, type, payload) values ($1,'run_completed','{}')",
-        [runId]
-      );
-      await t.none("update workflow_runs set status='succeeded', finished_at=strftime('%Y-%m-%dT%H:%M:%fZ','now'), updated_at=strftime('%Y-%m-%dT%H:%M:%fZ','now') where id=$1", [runId]);
-    });
+/** Advance one run: either finish it, or dispatch its next nodes. */
+export async function handleRun(message) {
+  const runId = message.run_id;
+
+  if (!runId) {
+    throw new Error("Run job is missing run_id");
+  }
+
+  // A job can be redelivered after its lease lapses, so completing a run has to
+  // be idempotent — otherwise a second run_completed event is appended and the
+  // finished_at timestamp is rewritten.
+  const run = await db.oneOrNone("select status from workflow_runs where id = ?", [runId]);
+
+  if (!run) {
+    console.warn(`run ${runId} no longer exists; dropping job`);
     return;
   }
+
+  if (run.status !== "running") {
+    console.log(`run ${runId} is already ${run.status}; nothing to do`);
+    return;
+  }
+
+  const nodes = await nextNodesFor(runId);
+
+  if (nodes.length === 0) {
+    await db.tx(async (t) => {
+      await t.none(
+        "insert into workflow_events (run_id, type, payload) values (?, 'run_completed', '{}')",
+        [runId],
+      );
+      await t.none(
+        `update workflow_runs
+            set status = 'succeeded',
+                finished_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
+                updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+          where id = ?`,
+        [runId],
+      );
+    });
+    console.log(`✓ run ${runId} completed`);
+    return;
+  }
+
   for (const node of nodes) {
     await db.none(
-      "insert into workflow_events (run_id, type, payload) values ($1,'step_started',$2)",
-      [runId, JSON.stringify({ node })]
+      "insert into workflow_events (run_id, type, payload) values (?, 'step_started', ?)",
+      [runId, JSON.stringify({ node })],
     );
     await enqueueStep(runId, node);
   }
 }
 
-export async function startOrchestrator() {
-  await queue.process("run:orchestrate", handleRun);
-  console.log("🧠 MeshHook Orchestrator running");
+/**
+ * Execute one node, then ask the orchestrator to advance the run.
+ *
+ * Re-enqueueing the run is what closes the loop: the step writes its events,
+ * and the next run job recomputes where the workflow goes from there.
+ */
+export async function handleStep(message) {
+  const { run_id: runId, node } = message;
+
+  if (!runId || !node) {
+    throw new Error("Step job is missing run_id or node");
+  }
+
+  await executeStep(runId, node);
+  await enqueueRun(runId);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) startOrchestrator();
+/** Fail fast and legibly rather than crash-looping on the first query. */
+function assertConfigured() {
+  const url =
+    process.env.TURSO_DATABASE_URL ?? process.env.DATABASE_URL ?? process.env.LIBSQL_URL;
+
+  if (!url) {
+    console.error(
+      "✗ TURSO_DATABASE_URL is not set.\n" +
+        "  Set it to a libsql:// URL (Turso) or a file: path for local runs.\n" +
+        "  Create one with: turso db create meshhook && turso db show meshhook --url",
+    );
+    process.exit(1);
+  }
+
+  if (/^postgres(ql)?:\/\//i.test(url)) {
+    console.error(
+      "✗ TURSO_DATABASE_URL looks like a Postgres URL.\n" +
+        "  MeshHook migrated from Supabase to Turso; expected libsql:// or file:.",
+    );
+    process.exit(1);
+  }
+}
+
+export async function startOrchestrator() {
+  assertConfigured();
+
+  // Surface a bad URL or token now, rather than on the first job.
+  try {
+    await db.one("select 1 as ok");
+  } catch (error) {
+    console.error(`✗ Cannot reach the database: ${error.message}`);
+    process.exit(1);
+  }
+
+  const runWorker = new Worker({
+    queueName: RUN_QUEUE,
+    jobHandler: handleRun,
+    pollIntervalMs: Number(process.env.POLL_INTERVAL_MS ?? 1000),
+  });
+
+  const stepWorker = new Worker({
+    queueName: STEP_QUEUE,
+    jobHandler: handleStep,
+    pollIntervalMs: Number(process.env.POLL_INTERVAL_MS ?? 1000),
+    visibilityTimeoutSeconds: 120,
+  });
+
+  await runWorker.start();
+  await stepWorker.start();
+
+  console.log("🧠 MeshHook Orchestrator running");
+  console.log(`   queues: ${RUN_QUEUE}, ${STEP_QUEUE}`);
+
+  // Railway sends SIGTERM on redeploy; finish the in-flight job rather than
+  // dropping its lease and waiting for the visibility timeout to expire.
+  let stopping = false;
+  const shutdown = async (signal) => {
+    if (stopping) return;
+    stopping = true;
+    console.log(`\n${signal} received, stopping workers...`);
+
+    await Promise.allSettled([runWorker.stop(), stepWorker.stop()]);
+    await db.close();
+
+    console.log("Orchestrator stopped");
+    process.exit(0);
+  };
+
+  process.on("SIGTERM", () => shutdown("SIGTERM"));
+  process.on("SIGINT", () => shutdown("SIGINT"));
+
+  return { runWorker, stepWorker };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  startOrchestrator().catch((error) => {
+    console.error(`✗ Orchestrator failed to start: ${error.message}`);
+    process.exit(1);
+  });
+}

--- a/workers/orchestrator.test.js
+++ b/workers/orchestrator.test.js
@@ -1,0 +1,200 @@
+/**
+ * Orchestrator tests.
+ *
+ * These cover the run-advancing logic that was rewired when the in-process
+ * EventEmitter was replaced by durable queues — in particular that a terminated
+ * run stops instead of restarting from its first node, and that completing a
+ * run is idempotent under redelivery.
+ *
+ * The orchestrator uses the shared db singleton, so TURSO_DATABASE_URL is set
+ * to a temp file before it is imported. No network: the http_call branch is
+ * never exercised here.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
+import { mkdtempSync, rmSync, readFileSync, readdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+import { fileURLToPath } from "node:url";
+
+const rootDir = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+let dir;
+let db;
+let orchestrator;
+let stepQueue;
+let runQueue;
+
+beforeAll(async () => {
+  dir = mkdtempSync(join(tmpdir(), "meshhook-orch-"));
+  process.env.TURSO_DATABASE_URL = `file:${join(dir, `${randomUUID()}.db`)}`;
+
+  const { splitStatements } = await import("../scripts/db-migrate.js");
+  ({ db } = await import("@meshhook/shared/lib/db.js"));
+
+  for (const file of readdirSync(join(rootDir, "migrations")).filter((f) => f.endsWith(".sql")).sort()) {
+    const sql = readFileSync(join(rootDir, "migrations", file), "utf8");
+    for (const statement of splitStatements(sql)) {
+      await db.none(statement);
+    }
+  }
+
+  orchestrator = await import("./orchestrator.mjs");
+  ({ stepQueue, runQueue } = await import("./lib/queue.js"));
+});
+
+afterAll(async () => {
+  await db?.close();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+/** A fresh project/workflow/run, plus helpers to drive its event log. */
+async function seedRun() {
+  const project = await db.one("insert into projects (owner, name) values (?, ?) returning id", [
+    randomUUID(),
+    "orch-test",
+  ]);
+  const workflow = await db.one(
+    `insert into workflow_definitions (project_id, slug, name, definition)
+     values (?, ?, ?, ?) returning id`,
+    [project.id, `wf-${randomUUID()}`, "WF", JSON.stringify({ nodes: [] })],
+  );
+  const run = await db.one(
+    `insert into workflow_runs (project_id, workflow_id, status)
+     values (?, ?, 'running') returning id`,
+    [project.id, workflow.id],
+  );
+  return run.id;
+}
+
+const succeed = (runId, node, next) =>
+  db.none("insert into workflow_events (run_id, type, payload) values (?, 'step_succeeded', ?)", [
+    runId,
+    JSON.stringify({ node, next }),
+  ]);
+
+const statusOf = async (runId) =>
+  (await db.one("select status from workflow_runs where id = ?", [runId])).status;
+
+const eventTypes = async (runId) =>
+  (await db.manyOrNone("select type from workflow_events where run_id = ? order by id", [runId])).map(
+    (e) => e.type,
+  );
+
+describe("nextNodesFor", () => {
+  let runId;
+  beforeEach(async () => {
+    runId = await seedRun();
+  });
+
+  it("starts a fresh run at the first node", async () => {
+    expect(await orchestrator.nextNodesFor(runId)).toEqual([{ id: "mapLead", type: "transform" }]);
+  });
+
+  it("advances through the pipeline", async () => {
+    await succeed(runId, { id: "mapLead", type: "transform" }, "mapLead");
+    expect(await orchestrator.nextNodesFor(runId)).toEqual([
+      { id: "createContact", type: "http_call" },
+    ]);
+
+    await succeed(runId, { id: "createContact", type: "http_call" }, "createContact");
+    expect(await orchestrator.nextNodesFor(runId)).toEqual([{ id: "terminate", type: "terminate" }]);
+  });
+
+  it("stops after a terminate node rather than restarting", async () => {
+    await succeed(runId, { id: "mapLead", type: "transform" }, "mapLead");
+    await succeed(runId, { id: "createContact", type: "http_call" }, "createContact");
+    // terminate reports next: null, which alone looks identical to "not started".
+    await succeed(runId, { id: "terminate", type: "terminate" }, null);
+
+    expect(await orchestrator.nextNodesFor(runId)).toEqual([]);
+  });
+
+  it("stops once a run_completed event exists", async () => {
+    await db.none("insert into workflow_events (run_id, type, payload) values (?, 'run_completed', '{}')", [
+      runId,
+    ]);
+    expect(await orchestrator.nextNodesFor(runId)).toEqual([]);
+  });
+});
+
+describe("handleRun", () => {
+  let runId;
+  beforeEach(async () => {
+    runId = await seedRun();
+    await stepQueue.purge();
+    await runQueue.purge();
+  });
+
+  it("records step_started and enqueues the step", async () => {
+    await orchestrator.handleRun({ run_id: runId });
+
+    expect(await eventTypes(runId)).toEqual(["step_started"]);
+
+    const queued = await stepQueue.peek(10);
+    expect(queued).toHaveLength(1);
+    expect(queued[0].message).toMatchObject({ run_id: runId, node: { id: "mapLead" } });
+  });
+
+  it("completes a terminated run", async () => {
+    await succeed(runId, { id: "terminate", type: "terminate" }, null);
+
+    await orchestrator.handleRun({ run_id: runId });
+
+    expect(await statusOf(runId)).toBe("succeeded");
+    expect(await eventTypes(runId)).toContain("run_completed");
+  });
+
+  it("is idempotent when the job is redelivered", async () => {
+    await succeed(runId, { id: "terminate", type: "terminate" }, null);
+
+    await orchestrator.handleRun({ run_id: runId });
+    await orchestrator.handleRun({ run_id: runId });
+
+    // A second completion would append another run_completed and rewrite
+    // finished_at.
+    const completed = (await eventTypes(runId)).filter((t) => t === "run_completed");
+    expect(completed).toHaveLength(1);
+  });
+
+  it("drops a job whose run no longer exists", async () => {
+    await expect(orchestrator.handleRun({ run_id: randomUUID() })).resolves.toBeUndefined();
+  });
+
+  it("rejects a job with no run_id", async () => {
+    await expect(orchestrator.handleRun({})).rejects.toThrow(/missing run_id/);
+  });
+});
+
+describe("handleStep", () => {
+  let runId;
+  beforeEach(async () => {
+    runId = await seedRun();
+    await stepQueue.purge();
+    await runQueue.purge();
+  });
+
+  it("executes a transform and re-enqueues the run", async () => {
+    await orchestrator.handleStep({ run_id: runId, node: { id: "mapLead", type: "transform" } });
+
+    expect(await eventTypes(runId)).toEqual(["step_succeeded"]);
+
+    // Re-enqueueing the run is what closes the loop.
+    const queued = await runQueue.peek(10);
+    expect(queued).toHaveLength(1);
+    expect(queued[0].message.run_id).toBe(runId);
+  });
+
+  it("rejects an unknown node type instead of reporting success", async () => {
+    await expect(
+      orchestrator.handleStep({ run_id: runId, node: { id: "x", type: "nope" } }),
+    ).rejects.toThrow(/Unknown node type/);
+
+    expect(await eventTypes(runId)).toEqual([]);
+  });
+
+  it("rejects a malformed job", async () => {
+    await expect(orchestrator.handleStep({ run_id: runId })).rejects.toThrow(/missing run_id or node/);
+  });
+});


### PR DESCRIPTION
The `meshhook` Railway service reports **EXITED** on every deploy. The build is fine — the process genuinely ends.

## Why

`startOrchestrator()` registered two EventEmitter listeners and returned. `bus.on(...)` does not hold the Node event loop open, so the process printed its banner and exited immediately.

The same EventEmitter was also why work went nowhere. The web app enqueues a run when a webhook arrives; the orchestrator listened on its own in-process bus **in a different container** and never heard it. #234 fixed the producer to write to the durable queue but left the consumer on the bus, so runs were still silently dropped.

## What changed

Both queues are now database-backed:

| queue | purpose |
|---|---|
| `workflow_jobs` | a run needs its next step decided |
| `workflow_steps` | a node needs executing |

The orchestrator polls both with the existing `Worker`. That keeps the process alive, lets several instances share the work, and means queued work survives a restart.

Steps get a 120s visibility timeout rather than the default 30s — a step makes an outbound HTTP call with its own retries, and a shorter lease could lapse while the work is legitimately still in flight, causing a duplicate execution.

## Bugs found while rewiring

- **A terminated run restarted forever.** A terminate node reports `next: null`, which replay could not distinguish from "not started", so it looped back to the first node. Replay now tracks termination separately.
- **Completing a run was not idempotent** — a redelivered job appended a second `run_completed` event and rewrote `finished_at`.
- **An unknown node type silently succeeded**, letting a run complete as though an unexecutable node had worked. It now throws, so the job retries or dead-letters.
- **Missing config crash-looped.** The process now exits non-zero with a clear message when `TURSO_DATABASE_URL` is unset or still points at Postgres.
- **SIGTERM dropped in-flight leases.** Redeploys now drain before exiting instead of stranding jobs until their visibility timeout expires.

## Verification

End to end against a local libSQL file:

```
seeded run 08cba119-…
ALIVE: orchestrator still running after 8s
events: step_started, step_succeeded, step_started, step_succeeded, run_completed
queued: (empty)
exited cleanly on SIGTERM
```

380 tests passing (122 vitest including 12 new orchestrator tests, 258 node:test). Web app still builds.

## Still needed to actually run in production

The service has **no application environment variables set** — no `TURSO_DATABASE_URL`, `TURSO_AUTH_TOKEN`, or `SECRETS_ENCRYPTION_KEY`. With this change it will exit(1) with a clear message instead of crash-looping, but it still needs a database before it can do any work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)